### PR TITLE
Maximale Länge für Gerichtsbeschreibung auf 500 Zeichen erhöht

### DIFF
--- a/src/Gastromio.App/ClientApp/src/app/restaurant-admin/components/edit-dish/edit-dish.component.html
+++ b/src/Gastromio.App/ClientApp/src/app/restaurant-admin/components/edit-dish/edit-dish.component.html
@@ -29,7 +29,9 @@
                             <div class="input-inner">
                                 <div style="background: none; border-radius: 0px; bottom: -1px; left: 0px; right: 0px; top: 0px;"></div>
                                 <label>
-                                    <div class="label">Beschreibung des Gerichts (optional)</div>
+                                    <div class="label">Beschreibung des Gerichts (optional) 
+                                        <span *ngIf="!!editDishForm.value && !!editDishForm.value.description">{{editDishForm.value.description.length}} / {{maxStringLength}}</span>
+                                    </div>
                                     <input type="text" mozactionhint="next" autocomplete="off" autocapitalize="off" spellcheck="true" id="description" formControlName="description" maxlength="500">
                                 </label>
                                 <div class="border" style="border: 1px solid rgb(176, 176, 176); border-radius: 0px; bottom: -1px; left: 0px; right: 0px; top: 0px; z-index: 0;"></div>
@@ -39,7 +41,9 @@
                             <div class="input-inner">
                                 <div style="background: none; border-radius: 0px; bottom: -1px; left: 0px; right: 0px; top: 0px;"></div>
                                 <label>
-                                    <div class="label">Zusatzstoffe und Allergene (optional)</div>
+                                    <div class="label">Zusatzstoffe und Allergene (optional) 
+                                        <span *ngIf="!!editDishForm.value && !!editDishForm.value.productInfo">{{editDishForm.value.productInfo.length}} / {{maxStringLength}}</span>
+                                    </div>
                                     <input type="text" mozactionhint="next" autocomplete="off" autocapitalize="off" spellcheck="false" id="productInfo" formControlName="productInfo" maxlength="500">
                                 </label>
                                 <div class="border" style="border: 1px solid rgb(176, 176, 176); border-radius: 0px; bottom: -1px; left: 0px; right: 0px; top: 0px; z-index: 0;"></div>

--- a/src/Gastromio.App/ClientApp/src/app/restaurant-admin/components/edit-dish/edit-dish.component.html
+++ b/src/Gastromio.App/ClientApp/src/app/restaurant-admin/components/edit-dish/edit-dish.component.html
@@ -30,7 +30,7 @@
                                 <div style="background: none; border-radius: 0px; bottom: -1px; left: 0px; right: 0px; top: 0px;"></div>
                                 <label>
                                     <div class="label">Beschreibung des Gerichts (optional)</div>
-                                    <input type="text" mozactionhint="next" autocomplete="off" autocapitalize="off" spellcheck="true" id="description" formControlName="description">
+                                    <input type="text" mozactionhint="next" autocomplete="off" autocapitalize="off" spellcheck="true" id="description" formControlName="description" maxlength="500">
                                 </label>
                                 <div class="border" style="border: 1px solid rgb(176, 176, 176); border-radius: 0px; bottom: -1px; left: 0px; right: 0px; top: 0px; z-index: 0;"></div>
                             </div>
@@ -40,7 +40,7 @@
                                 <div style="background: none; border-radius: 0px; bottom: -1px; left: 0px; right: 0px; top: 0px;"></div>
                                 <label>
                                     <div class="label">Zusatzstoffe und Allergene (optional)</div>
-                                    <input type="text" mozactionhint="next" autocomplete="off" autocapitalize="off" spellcheck="false" id="productInfo" formControlName="productInfo">
+                                    <input type="text" mozactionhint="next" autocomplete="off" autocapitalize="off" spellcheck="false" id="productInfo" formControlName="productInfo" maxlength="500">
                                 </label>
                                 <div class="border" style="border: 1px solid rgb(176, 176, 176); border-radius: 0px; bottom: -1px; left: 0px; right: 0px; top: 0px; z-index: 0;"></div>
                             </div>
@@ -50,7 +50,7 @@
                                 <div style="background: none; border-radius: 0px 0px 8px 8px; bottom: -1px; left: 0px; right: 0px; top: 0px;"></div>
                                 <label>
                                     <div class="label">Preis des Gerichts</div>
-                                    <input type="number" id="price" [(ngModel)]="price" [ngModelOptions]="{standalone: true}">
+                                    <input type="number" id="price" [(ngModel)]="price" [ngModelOptions]="{standalone: true}" min="0" step=".01">
                                 </label>
                                 <div class="border" style="border: 1px solid rgb(176, 176, 176); border-radius: 0px 0px 8px 8px; bottom: -1px; left: 0px; right: 0px; top: 0px; z-index: 0;"></div>
                             </div>
@@ -79,7 +79,7 @@
                                                 <div style="background: none; border-radius: 0px; bottom: -1px; left: 0px; right: 0px; top: 0px;"></div>
                                                 <label>
                                                     <div class="label">Preis des Variante</div>
-                                                    <input type="number" autocomplete="off" class="form-control" [(ngModel)]="variant.price" [ngModelOptions]="{standalone: true}">
+                                                    <input type="number" autocomplete="off" class="form-control" [(ngModel)]="variant.price" [ngModelOptions]="{standalone: true}" min="0" step=".01">
                                                 </label>
                                                 <div class="border" style="border: 1px solid rgb(176, 176, 176); border-radius: 0px; bottom: -1px; left: 0px; right: 0px; top: 0px; z-index: 0;"></div>
                                             </td>

--- a/src/Gastromio.App/ClientApp/src/app/restaurant-admin/components/edit-dish/edit-dish.component.ts
+++ b/src/Gastromio.App/ClientApp/src/app/restaurant-admin/components/edit-dish/edit-dish.component.ts
@@ -53,9 +53,9 @@ export class EditDishComponent implements OnInit {
     this.isNew = this.dish.id === undefined;
 
     this.editDishForm = this.formBuilder.group({
-      name: [this.dish.name, Validators.required],
-      description: [this.dish.description],
-      productInfo: [this.dish.productInfo],
+      name: [this.dish.name, Validators.required,],
+      description: [this.dish.description, Validators.maxLength(500)],
+      productInfo: [this.dish.productInfo, Validators.maxLength(500)],
     });
 
     if (this.dish.variants.length === 0) {

--- a/src/Gastromio.App/ClientApp/src/app/restaurant-admin/components/edit-dish/edit-dish.component.ts
+++ b/src/Gastromio.App/ClientApp/src/app/restaurant-admin/components/edit-dish/edit-dish.component.ts
@@ -24,6 +24,9 @@ import {RestaurantAdminFacade} from "../../restaurant-admin.facade";
   ]
 })
 export class EditDishComponent implements OnInit {
+  
+  public readonly maxStringLength = 500; 
+  
   @Input() public dishCategoryId: string;
   @Input() public dish: DishModel;
   @BlockUI() blockUI: NgBlockUI;
@@ -54,8 +57,8 @@ export class EditDishComponent implements OnInit {
 
     this.editDishForm = this.formBuilder.group({
       name: [this.dish.name, Validators.required,],
-      description: [this.dish.description, Validators.maxLength(500)],
-      productInfo: [this.dish.productInfo, Validators.maxLength(500)],
+      description: [this.dish.description, Validators.maxLength(this.maxStringLength)],
+      productInfo: [this.dish.productInfo, Validators.maxLength(this.maxStringLength)],
     });
 
     if (this.dish.variants.length === 0) {

--- a/src/Gastromio.App/Controllers/V1/RestaurantAdminController.cs
+++ b/src/Gastromio.App/Controllers/V1/RestaurantAdminController.cs
@@ -616,7 +616,7 @@ namespace Gastromio.App.Controllers.V1
                 new AddOrChangeDishOfRestaurantCommand(
                     new RestaurantId(restaurantId),
                     new DishCategoryId(model.DishCategoryId),
-                    model.Dish.Id,
+                    new DishId(model.Dish.Id),
                     model.Dish.Name,
                     model.Dish.Description,
                     model.Dish.ProductInfo,

--- a/src/Gastromio.Core/Application/Commands/AddOrChangeDishOfRestaurant/AddOrChangeDishOfRestaurantCommand.cs
+++ b/src/Gastromio.Core/Application/Commands/AddOrChangeDishOfRestaurant/AddOrChangeDishOfRestaurantCommand.cs
@@ -12,7 +12,7 @@ namespace Gastromio.Core.Application.Commands.AddOrChangeDishOfRestaurant
     public class AddOrChangeDishOfRestaurantCommand : ICommand<Guid>
     {
         public AddOrChangeDishOfRestaurantCommand(RestaurantId restaurantId, DishCategoryId dishCategoryId,
-            Guid dishId, string name, string description, string productInfo, int orderNo, IEnumerable<DishVariant> variants)
+            DishId dishId, string name, string description, string productInfo, int orderNo, IEnumerable<DishVariant> variants)
         {
             RestaurantId = restaurantId;
             DishCategoryId = dishCategoryId;
@@ -28,7 +28,7 @@ namespace Gastromio.Core.Application.Commands.AddOrChangeDishOfRestaurant
         
         public DishCategoryId DishCategoryId { get; }
 
-        public Guid DishId { get; }
+        public DishId DishId { get; }
         
         public string Name { get; }
         

--- a/src/Gastromio.Core/Application/Commands/AddOrChangeDishOfRestaurant/AddOrChangeDishOfRestaurantCommandHandler.cs
+++ b/src/Gastromio.Core/Application/Commands/AddOrChangeDishOfRestaurant/AddOrChangeDishOfRestaurantCommandHandler.cs
@@ -52,10 +52,11 @@ namespace Gastromio.Core.Application.Commands.AddOrChangeDishOfRestaurant
                 return FailureResult<Guid>.Create(FailureResultCode.DishCategoryDoesNotBelongToRestaurant);
 
             Dish dish;
-            if (command.DishId != Guid.Empty)
+            if (command.DishId.Value != Guid.Empty)
             {
                 var dishes = await dishRepository.FindByDishCategoryIdAsync(dishCategory.Id, cancellationToken);
-                dish = dishes?.FirstOrDefault(en => en.Id.Value == command.DishId);
+                dish = dishes?.FirstOrDefault(en => en.Id == command.DishId);
+
                 if (dish == null)
                     return FailureResult<Guid>.Create(FailureResultCode.DishDoesNotBelongToDishCategory);
 

--- a/src/Gastromio.Core/Domain/Model/Dishes/Dish.cs
+++ b/src/Gastromio.Core/Domain/Model/Dishes/Dish.cs
@@ -160,6 +160,9 @@ namespace Gastromio.Core.Domain.Model.Dishes
 
             foreach (var variant in newVariants)
             {
+                if (variants == null)
+                    throw new NullReferenceException(nameof(variant));
+
                 var tempResult = AddVariant(tempVariants, variant.VariantId, variant.Name, variant.Price);
                 if (tempResult.IsFailure)
                     return tempResult;

--- a/src/Gastromio.Core/Domain/Model/Dishes/Dish.cs
+++ b/src/Gastromio.Core/Domain/Model/Dishes/Dish.cs
@@ -11,6 +11,11 @@ namespace Gastromio.Core.Domain.Model.Dishes
 {
     public class Dish
     {
+        private const int MaxNameLength = 40;
+        private const int MaxDescriptionLength = 500;
+        private const int MaxProductInfoLength = 500;
+        private const int MaxVariantPrice = 200;
+
         private IList<DishVariant> variants;
 
         public Dish(
@@ -70,8 +75,8 @@ namespace Gastromio.Core.Domain.Model.Dishes
         {
             if (string.IsNullOrEmpty(name))
                 return FailureResult<bool>.Create(FailureResultCode.DishNameRequired);
-            if (name.Length > 40)
-                return FailureResult<bool>.Create(FailureResultCode.DishNameTooLong, 40);
+            if (name.Length > MaxNameLength)
+                return FailureResult<bool>.Create(FailureResultCode.DishNameTooLong, MaxNameLength);
 
             Name = name;
             UpdatedOn = DateTimeOffset.UtcNow;
@@ -82,8 +87,8 @@ namespace Gastromio.Core.Domain.Model.Dishes
 
         public Result<bool> ChangeDescription(string description, UserId changedBy)
         {
-            if (description != null && description.Length > 200)
-                return FailureResult<bool>.Create(FailureResultCode.DishDescriptionTooLong,  200);
+            if (description != null && description.Length > MaxDescriptionLength)
+                return FailureResult<bool>.Create(FailureResultCode.DishDescriptionTooLong, MaxDescriptionLength);
 
             Description = description;
             UpdatedOn = DateTimeOffset.UtcNow;
@@ -94,8 +99,8 @@ namespace Gastromio.Core.Domain.Model.Dishes
 
         public Result<bool> ChangeProductInfo(string productInfo, UserId changedBy)
         {
-            if (productInfo != null && productInfo.Length > 200)
-                return FailureResult<bool>.Create(FailureResultCode.DishProductInfoTooLong,  200);
+            if (productInfo != null && productInfo.Length > MaxProductInfoLength)
+                return FailureResult<bool>.Create(FailureResultCode.DishProductInfoTooLong, MaxProductInfoLength);
 
             ProductInfo = productInfo;
             UpdatedOn = DateTimeOffset.UtcNow;
@@ -177,12 +182,12 @@ namespace Gastromio.Core.Domain.Model.Dishes
             if (variants.Any(en => en.VariantId == variantId))
                 throw new InvalidOperationException("variant already exists");
 
-            if (name != null && name.Length > 40)
-                return FailureResult<bool>.Create(FailureResultCode.DishVariantNameTooLong, 40);
+            if (name != null && name.Length > MaxNameLength)
+                return FailureResult<bool>.Create(FailureResultCode.DishVariantNameTooLong, MaxNameLength);
 
             if (!(price > 0))
                 return FailureResult<bool>.Create(FailureResultCode.DishVariantPriceIsNegativeOrZero);
-            if (price > 200)
+            if (price > MaxVariantPrice)
                 return FailureResult<bool>.Create(FailureResultCode.DishVariantPriceIsTooBig);
 
             variants.Add(new DishVariant(variantId, name, price));

--- a/test/Gastromio.Domain.TestKit/Domain/Model/Dishes/DishVariantBuilder.cs
+++ b/test/Gastromio.Domain.TestKit/Domain/Model/Dishes/DishVariantBuilder.cs
@@ -8,7 +8,7 @@ namespace Gastromio.Domain.TestKit.Domain.Model.Dishes
     {
         public DishVariantBuilder WithValidConstrains()
         {
-            WithPrice(1.23m);
+            WithRangeConstrainedIntegerConstructorArgumentFor("price", 0, 200);
             return this;
         }
 

--- a/test/Gastromio.Domain.TestKit/Domain/Model/Dishes/DishVariantBuilder.cs
+++ b/test/Gastromio.Domain.TestKit/Domain/Model/Dishes/DishVariantBuilder.cs
@@ -8,7 +8,7 @@ namespace Gastromio.Domain.TestKit.Domain.Model.Dishes
     {
         public DishVariantBuilder WithValidConstrains()
         {
-            WithRangeConstrainedIntegerConstructorArgumentFor("price", 0, 200);
+            WithRangeConstrainedDecimalConstructorArgumentFor("price", 0, 200);
             return this;
         }
 

--- a/test/Gastromio.Domain.Tests/Application/CommandHandlerTestBase.cs
+++ b/test/Gastromio.Domain.Tests/Application/CommandHandlerTestBase.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Gastromio.Core.Application.Commands;
+using Gastromio.Core.Common;
 using Gastromio.Core.Domain.Model.Users;
 using Xunit;
 
@@ -132,6 +134,19 @@ namespace Gastromio.Domain.Tests.Application
                 {
                     result?.IsSuccess.Should().BeTrue();
                 }
+            }
+        }
+
+        public void AssertFailure(Result<TResult> result, FailureResultCode failureCode)
+        {
+            using (new AssertionScope())
+            {
+                result.Should().NotBeNull();
+                result?.IsFailure.Should().BeTrue();
+                FailureResult<TResult> fr = (FailureResult<TResult>)result;
+                fr.Should().NotBeNull();
+                fr.Errors.Should().HaveCount(1);
+                fr.Errors.Values.First().First().Code.Should().Be(failureCode);
             }
         }
     }

--- a/test/Gastromio.Domain.Tests/Application/Commands/AddOrChangeDishOfRestaurant/AddDishOfRestaurantCommandHandlerTests.cs
+++ b/test/Gastromio.Domain.Tests/Application/Commands/AddOrChangeDishOfRestaurant/AddDishOfRestaurantCommandHandlerTests.cs
@@ -20,13 +20,13 @@ using Xunit;
 
 namespace Gastromio.Domain.Tests.Application.Commands.AddOrChangeDishOfRestaurant
 {
-    public class AddOrChangeDishOfRestaurantCommandHandlerTests : CommandHandlerTestBase<
+    public class AddDishOfRestaurantCommandHandlerTests : CommandHandlerTestBase<
         AddOrChangeDishOfRestaurantCommandHandler,
         AddOrChangeDishOfRestaurantCommand, Guid>
     {
         private readonly Fixture fixture;
 
-        public AddOrChangeDishOfRestaurantCommandHandlerTests()
+        public AddDishOfRestaurantCommandHandlerTests()
         {
             fixture = new Fixture(Role.RestaurantAdmin);
         }
@@ -161,9 +161,9 @@ namespace Gastromio.Domain.Tests.Application.Commands.AddOrChangeDishOfRestauran
             public void SetupRandomDish()
             {
                 Dish = new DishBuilder()
+                    .WithValidConstrains()
                     .WithRestaurantId(Restaurant.Id)
                     .WithCategoryId(DishCategory.Id)
-                    .WithOrderNo(0)
                     .WithCreatedBy(UserId)
                     .WithCreatedOn(DateTimeOffset.Now)
                     .WithUpdatedBy(UserId)

--- a/test/Gastromio.Domain.Tests/Application/Commands/AddOrChangeDishOfRestaurant/AddOrChangeDishOfRestaurantCommandHandlerTests.cs
+++ b/test/Gastromio.Domain.Tests/Application/Commands/AddOrChangeDishOfRestaurant/AddOrChangeDishOfRestaurantCommandHandlerTests.cs
@@ -122,7 +122,7 @@ namespace Gastromio.Domain.Tests.Application.Commands.AddOrChangeDishOfRestauran
                 return new AddOrChangeDishOfRestaurantCommand(
                     Restaurant.Id,
                     Dish.CategoryId,
-                    Guid.Empty,
+                    new DishId(Guid.Empty),
                     Dish.Name,
                     Dish.Description,
                     Dish.ProductInfo,

--- a/test/Gastromio.Domain.Tests/Application/Commands/AddOrChangeDishOfRestaurant/ChangeDishOfRestaurantCommandHandlerTests.cs
+++ b/test/Gastromio.Domain.Tests/Application/Commands/AddOrChangeDishOfRestaurant/ChangeDishOfRestaurantCommandHandlerTests.cs
@@ -1,0 +1,382 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Gastromio.Core.Application.Commands.AddOrChangeDishOfRestaurant;
+using Gastromio.Core.Common;
+using Gastromio.Core.Domain.Model.DishCategories;
+using Gastromio.Core.Domain.Model.Dishes;
+using Gastromio.Core.Domain.Model.Restaurants;
+using Gastromio.Core.Domain.Model.Users;
+using Gastromio.Domain.TestKit.Application.Ports.Persistence;
+using Gastromio.Domain.TestKit.Domain.Model.DishCategories;
+using Gastromio.Domain.TestKit.Domain.Model.Dishes;
+using Gastromio.Domain.TestKit.Domain.Model.Restaurants;
+using Moq;
+using Xunit;
+
+namespace Gastromio.Domain.Tests.Application.Commands.AddOrChangeDishOfRestaurant
+{
+    public class ChangeDishOfRestaurantCommandHandlerTests : CommandHandlerTestBase<
+        AddOrChangeDishOfRestaurantCommandHandler,
+        AddOrChangeDishOfRestaurantCommand, Guid>
+    {
+        private readonly Fixture fixture;
+
+        public ChangeDishOfRestaurantCommandHandlerTests()
+        {
+            fixture = new Fixture(Role.RestaurantAdmin);
+        }
+
+        [Fact]
+        public async Task HandleAsync_AllValid_EditDishAndReturnsSuccess()
+        {
+            // Arrange
+            fixture.SetupForSuccessfulCommandExecution(fixture.MinimumRole);
+
+            var testObject = fixture.CreateTestObject();
+            var expectedName = "Unit-Test";
+            var expectedDescription = "Changed in Unit-Test";
+            var expectedInfo = "CommandHandlerTest";
+            var expectedOrderNo = 2;
+            var expectedVariants = new List<DishVariant> { new DishVariant(Guid.NewGuid(), "Unit-Test", 5) };
+            var command = fixture.CreateSuccessfulEditCommand(expectedName, expectedDescription, expectedInfo, expectedOrderNo, expectedVariants);
+
+            // Act
+            var result = await testObject.HandleAsync(command, fixture.UserWithMinimumRole, CancellationToken.None);
+
+            // Assert
+            using (new AssertionScope())
+            {
+                result.Should().NotBeNull();
+                result?.IsSuccess.Should().BeTrue();
+                fixture.Dish.Should().BeEquivalentTo(new
+                {
+                    Name = expectedName,
+                    Description = expectedDescription,
+                    ProductInfo = expectedInfo,
+                    OrderNo = expectedOrderNo,
+                    Variants = expectedVariants
+                }, opt => opt.ExcludingMissingMembers());
+            }
+        }
+
+        [Fact]
+        public async Task HandleAsync_ChangeDishName_ShouldFailWithouGiventName()
+        {
+            // Arrange
+            fixture.SetupForSuccessfulCommandExecution(fixture.MinimumRole);
+
+            var testObject = fixture.CreateTestObject();
+            var command = fixture.CreateSuccessfulEditCommand(string.Empty);
+
+            // Act
+            var result = await testObject.HandleAsync(command, fixture.UserWithMinimumRole, CancellationToken.None);
+
+            // Assert
+            AssertFailure(result, FailureResultCode.DishNameRequired);
+        }
+
+        [Fact]
+        public async Task HandleAsync_ChangeDishName_ShouldFailWithToManyCharacters()
+        {
+            // Arrange
+            fixture.SetupForSuccessfulCommandExecution(fixture.MinimumRole);
+
+            var testObject = fixture.CreateTestObject();
+            var expectedChange = new string('*', 41);
+            var command = fixture.CreateSuccessfulEditCommand(expectedChange);
+
+            // Act
+            var result = await testObject.HandleAsync(command, fixture.UserWithMinimumRole, CancellationToken.None);
+
+            AssertFailure(result, FailureResultCode.DishNameTooLong);
+        }
+
+        [Fact]
+        public async Task HandleAsync_ChangeDishDescription_ShouldFailWithToManyCharacters()
+        {
+            // Arrange
+            fixture.SetupForSuccessfulCommandExecution(fixture.MinimumRole);
+
+            var testObject = fixture.CreateTestObject();
+            var expectedChange = new string('*', 501);
+            var command = fixture.CreateSuccessfulEditCommand(null, expectedChange);
+
+            // Act
+            var result = await testObject.HandleAsync(command, fixture.UserWithMinimumRole, CancellationToken.None);
+
+            AssertFailure(result, FailureResultCode.DishDescriptionTooLong);
+        }
+
+        [Fact]
+        public async Task HandleAsync_ChangeDishInfo_ShouldFailWithToManyCharacters()
+        {
+            // Arrange
+            fixture.SetupForSuccessfulCommandExecution(fixture.MinimumRole);
+
+            var testObject = fixture.CreateTestObject();
+            var expectedChange = new string('*', 501);
+            var command = fixture.CreateSuccessfulEditCommand(null, null, expectedChange);
+
+            // Act
+            var result = await testObject.HandleAsync(command, fixture.UserWithMinimumRole, CancellationToken.None);
+
+            AssertFailure(result, FailureResultCode.DishProductInfoTooLong);
+        }
+
+        [Fact]
+        public async Task HandleAsync_ChangeDishOrderNumber_ShouldFailWithNegativeNumber()
+        {
+            // Arrange
+            fixture.SetupForSuccessfulCommandExecution(fixture.MinimumRole);
+
+            var testObject = fixture.CreateTestObject();
+            var command = fixture.CreateSuccessfulEditCommand(null, null, null, -1);
+
+            // Act
+            var result = await testObject.HandleAsync(command, fixture.UserWithMinimumRole, CancellationToken.None);
+
+            AssertFailure(result, FailureResultCode.DishInvalidOrderNo);
+        }
+
+        [Fact]
+        public async Task HandleAsync_ChangeDishVariant_ShouldThrowWithoutVariants()
+        {
+            // Arrange
+            fixture.SetupForSuccessfulCommandExecution(fixture.MinimumRole);
+
+            var testObject = fixture.CreateTestObject();
+            var expectedChange = new List<DishVariant> { null };
+            var command = fixture.CreateSuccessfulEditCommand(null, null, null, null, expectedChange);
+
+            // Act
+            var result = await testObject.HandleAsync(command, fixture.UserWithMinimumRole, CancellationToken.None);
+
+            AssertFailure(result, FailureResultCode.DishVariantNameTooLong);
+        }
+
+        [Fact]
+        public async Task HandleAsync_ChangeDishVariant_ShouldFailVariantNameTooLong()
+        {
+            // Arrange
+            fixture.SetupForSuccessfulCommandExecution(fixture.MinimumRole);
+
+            var testObject = fixture.CreateTestObject();
+            var expectedChange = new List<DishVariant> { new DishVariant(Guid.NewGuid(), new string('*', 41), 5) };
+            var command = fixture.CreateSuccessfulEditCommand(null, null, null, null, expectedChange);
+
+            // Act
+            var result = await testObject.HandleAsync(command, fixture.UserWithMinimumRole, CancellationToken.None);
+
+            AssertFailure(result, FailureResultCode.DishVariantNameTooLong);
+        }
+
+        [Fact]
+        public async Task HandleAsync_ChangeDishVariant_ShouldFailWithNegativePrice()
+        {
+            // Arrange
+            fixture.SetupForSuccessfulCommandExecution(fixture.MinimumRole);
+
+            var testObject = fixture.CreateTestObject();
+            var expectedChange = new List<DishVariant> { new DishVariant(Guid.NewGuid(), "Unit Test", -1) };
+            var command = fixture.CreateSuccessfulEditCommand(null, null, null, null, expectedChange);
+
+            // Act
+            var result = await testObject.HandleAsync(command, fixture.UserWithMinimumRole, CancellationToken.None);
+
+            AssertFailure(result, FailureResultCode.DishVariantPriceIsNegativeOrZero);
+        }
+
+        [Fact]
+        public async Task HandleAsync_ChangeDishVariant_ShouldFailPriceTooBig()
+        {
+            // Arrange
+            fixture.SetupForSuccessfulCommandExecution(fixture.MinimumRole);
+
+            var testObject = fixture.CreateTestObject();
+            var expectedChange = new List<DishVariant> { new DishVariant(Guid.NewGuid(), "Unit Test", 201) };
+            var command = fixture.CreateSuccessfulEditCommand(null, null, null, null, expectedChange);
+
+            // Act
+            var result = await testObject.HandleAsync(command, fixture.UserWithMinimumRole, CancellationToken.None);
+
+            AssertFailure(result, FailureResultCode.DishVariantPriceIsTooBig);
+        }
+
+        protected override
+            CommandHandlerTestFixtureBase<AddOrChangeDishOfRestaurantCommandHandler, AddOrChangeDishOfRestaurantCommand,
+                Guid> FixtureBase
+        {
+            get { return fixture; }
+        }
+
+        private sealed class Fixture : CommandHandlerTestFixtureBase<AddOrChangeDishOfRestaurantCommandHandler,
+            AddOrChangeDishOfRestaurantCommand, Guid>
+        {
+            public Fixture(Role? minimumRole) : base(minimumRole)
+            {
+                RestaurantRepositoryMock = new RestaurantRepositoryMock(MockBehavior.Strict);
+                DishCategoryRepositoryMock = new DishCategoryRepositoryMock(MockBehavior.Strict);
+                DishRepositoryMock = new DishRepositoryMock(MockBehavior.Strict);
+                DishFactoryMock = new DishFactoryMock(MockBehavior.Strict);
+            }
+
+            public RestaurantRepositoryMock RestaurantRepositoryMock { get; }
+
+            public DishCategoryRepositoryMock DishCategoryRepositoryMock { get; }
+
+            public DishRepositoryMock DishRepositoryMock { get; }
+
+            public DishFactoryMock DishFactoryMock { get; }
+
+            public Restaurant Restaurant { get; private set; }
+
+            public DishCategory DishCategory { get; private set; }
+
+            public Dish Dish { get; private set; }
+
+            public override AddOrChangeDishOfRestaurantCommandHandler CreateTestObject()
+            {
+                return new AddOrChangeDishOfRestaurantCommandHandler(
+                    RestaurantRepositoryMock.Object,
+                    DishCategoryRepositoryMock.Object,
+                    DishRepositoryMock.Object,
+                    DishFactoryMock.Object
+                );
+            }
+
+            public AddOrChangeDishOfRestaurantCommand CreateSuccessfulEditCommand(string name = null, string desc = null, string info = null, int? order = null, IEnumerable<DishVariant> variants = null)
+            {
+                return new AddOrChangeDishOfRestaurantCommand(
+                    Restaurant.Id,
+                    Dish.CategoryId,
+                    Dish.Id,
+                    name ?? Dish.Name,
+                    desc ?? Dish.Description,
+                    info ?? Dish.ProductInfo,
+                    order.HasValue ? order.Value : Dish.OrderNo,
+                    variants ?? Dish.Variants
+                );
+            }
+
+            public void SetupRandomRestaurant(Role? role)
+            {
+                var builder = new RestaurantBuilder();
+
+                if (role == Role.RestaurantAdmin)
+                {
+                    builder = builder
+                        .WithAdministrators(new HashSet<UserId> {UserId});
+                }
+
+                Restaurant = builder
+                    .WithValidConstrains()
+                    .Create();
+            }
+
+            public void SetupRandomDishCategory()
+            {
+                DishCategory = new DishCategoryBuilder()
+                    .WithRestaurantId(Restaurant.Id)
+                    .WithOrderNo(0)
+                    .WithCreatedBy(UserId)
+                    .WithCreatedOn(DateTimeOffset.Now)
+                    .WithUpdatedBy(UserId)
+                    .WithUpdatedOn(DateTimeOffset.Now)
+                    .Create();
+            }
+
+            public void SetupRandomDish()
+            {
+                var variants = new DishVariantBuilder().WithValidConstrains().CreateMany(3);
+
+                Dish = new DishBuilder()
+                    .WithRestaurantId(Restaurant.Id)
+                    .WithCategoryId(DishCategory.Id)
+                    .WithOrderNo(0)
+                    .WithCreatedBy(UserId)
+                    .WithCreatedOn(DateTimeOffset.Now)
+                    .WithUpdatedBy(UserId)
+                    .WithUpdatedOn(DateTimeOffset.Now)
+                    .WithVariants(variants)
+                    .Create();
+            }
+
+            public void SetupRestaurantRepositoryFindingRestaurant()
+            {
+                RestaurantRepositoryMock.SetupFindByRestaurantIdAsync(Restaurant.Id)
+                    .ReturnsAsync(Restaurant);
+            }
+
+            public void SetupRestaurantRepositoryNotFindingRestaurant()
+            {
+                RestaurantRepositoryMock.SetupFindByRestaurantIdAsync(Restaurant.Id)
+                    .ReturnsAsync((Restaurant) null);
+            }
+
+            public void SetupDishCategoryRepositoryFindingDishCategory()
+            {
+                DishCategoryRepositoryMock.SetupFindByRestaurantIdAsync(Restaurant.Id)
+                    .ReturnsAsync(new[] {DishCategory});
+            }
+
+            public void SetupDishRepositoryFindingDishForDishCategory()
+            {
+                DishRepositoryMock.SetupFindByDishCategoryIdAsync(DishCategory.Id)
+                    .ReturnsAsync(new List<Dish> { Dish });
+            }
+
+            public void SetupDishRepositoryStoringDish()
+            {
+                DishRepositoryMock.SetupStoreAsync(Dish)
+                    .Returns(Task.CompletedTask);
+            }
+
+            public void SetupDishFactoryCreatingDish()
+            {
+                DishFactoryMock
+                    .SetupCreate(
+                        Restaurant.Id,
+                        DishCategory.Id,
+                        Dish.Name,
+                        Dish.Description,
+                        Dish.ProductInfo,
+                        Dish.OrderNo,
+                        Dish.Variants,
+                        DishCategory.CreatedBy
+                    )
+                    .Returns(SuccessResult<Dish>.Create(Dish));
+            }
+            public override AddOrChangeDishOfRestaurantCommand CreateSuccessfulCommand()
+            {
+                return new AddOrChangeDishOfRestaurantCommand(
+                   Restaurant.Id,
+                   Dish.CategoryId,
+                   Dish.Id,
+                   Dish.Name,
+                   Dish.Description,
+                   Dish.ProductInfo,
+                   Dish.OrderNo,
+                   Dish.Variants
+               );
+            }
+
+            public override void SetupForSuccessfulCommandExecution(Role? role)
+            {
+                SetupRandomRestaurant(role);
+                SetupRandomDishCategory();
+                SetupRandomDish();
+                SetupRestaurantRepositoryFindingRestaurant();
+                SetupDishCategoryRepositoryFindingDishCategory();
+                SetupDishRepositoryFindingDishForDishCategory();
+                SetupDishFactoryCreatingDish();
+                SetupDishRepositoryStoringDish();
+            }
+
+        }
+    }
+}

--- a/test/Gastromio.Domain.Tests/Application/Commands/AddOrChangeDishOfRestaurant/ChangeDishOfRestaurantCommandHandlerTests.cs
+++ b/test/Gastromio.Domain.Tests/Application/Commands/AddOrChangeDishOfRestaurant/ChangeDishOfRestaurantCommandHandlerTests.cs
@@ -292,7 +292,7 @@ namespace Gastromio.Domain.Tests.Application.Commands.AddOrChangeDishOfRestauran
 
             public void SetupRandomDish()
             {
-                var variants = new DishVariantBuilder().WithValidConstrains().CreateMany(3);
+                var variants = new DishVariantBuilder().WithValidConstrains().CreateMany(3).ToList();
 
                 Dish = new DishBuilder()
                     .WithRestaurantId(Restaurant.Id)

--- a/test/Gastromio.Domain.Tests/Domain/Model/Dishes/DishFactoryTests.cs
+++ b/test/Gastromio.Domain.Tests/Domain/Model/Dishes/DishFactoryTests.cs
@@ -240,13 +240,13 @@ namespace Gastromio.Domain.Tests.Domain.Model.Dishes
             public void SetupValidParametersExceptDescription()
             {
                 SetupValidParameters();
-                Description = RandomStringBuilder.BuildWithLength(201);
+                Description = RandomStringBuilder.BuildWithLength(501);
             }
 
             public void SetupValidParametersExceptProductInfo()
             {
                 SetupValidParameters();
-                ProductInfo = RandomStringBuilder.BuildWithLength(201);
+                ProductInfo = RandomStringBuilder.BuildWithLength(501);
             }
 
             public void SetupValidParametersExceptOrderNo()

--- a/test/Gastromio.Domain.Tests/Domain/Model/Dishes/DishTests.cs
+++ b/test/Gastromio.Domain.Tests/Domain/Model/Dishes/DishTests.cs
@@ -143,14 +143,14 @@ namespace Gastromio.Domain.Tests.Domain.Model.Dishes
         }
 
         [Fact]
-        public void ChangeDescription_DescriptionLength201_ReturnsFailure()
+        public void ChangeDescription_DescriptionLength501_ReturnsFailure()
         {
             // Arrange
             fixture.SetupChangedBy();
             fixture.SetupRandomVariants();
             var testObject = fixture.CreateTestObject();
 
-            var description = RandomStringBuilder.BuildWithLength(201);
+            var description = RandomStringBuilder.BuildWithLength(501);
 
             // Act
             var result = testObject.ChangeDescription(description, fixture.ChangedBy);
@@ -164,14 +164,14 @@ namespace Gastromio.Domain.Tests.Domain.Model.Dishes
         }
 
         [Fact]
-        public void ChangeDescription_DescriptionLength200_ChangesDescriptionAndReturnsSuccess()
+        public void ChangeDescription_DescriptionLength500_ChangesDescriptionAndReturnsSuccess()
         {
             // Arrange
             fixture.SetupChangedBy();
             fixture.SetupRandomVariants();
             var testObject = fixture.CreateTestObject();
 
-            var description = RandomStringBuilder.BuildWithLength(200);
+            var description = RandomStringBuilder.BuildWithLength(500);
 
             // Act
             var result = testObject.ChangeDescription(description, fixture.ChangedBy);
@@ -226,14 +226,14 @@ namespace Gastromio.Domain.Tests.Domain.Model.Dishes
         }
 
         [Fact]
-        public void ChangeProductInfo_ProductInfoLength201_ReturnsFailure()
+        public void ChangeProductInfo_ProductInfoLength501_ReturnsFailure()
         {
             // Arrange
             fixture.SetupChangedBy();
             fixture.SetupRandomVariants();
             var testObject = fixture.CreateTestObject();
 
-            var productInfo = RandomStringBuilder.BuildWithLength(201);
+            var productInfo = RandomStringBuilder.BuildWithLength(501);
 
             // Act
             var result = testObject.ChangeProductInfo(productInfo, fixture.ChangedBy);
@@ -247,14 +247,14 @@ namespace Gastromio.Domain.Tests.Domain.Model.Dishes
         }
 
         [Fact]
-        public void ChangeProductInfo_ProductInfoLength200_ChangesProductInfoAndReturnsSuccess()
+        public void ChangeProductInfo_ProductInfoLength500_ChangesProductInfoAndReturnsSuccess()
         {
             // Arrange
             fixture.SetupChangedBy();
             fixture.SetupRandomVariants();
             var testObject = fixture.CreateTestObject();
 
-            var productInfo = RandomStringBuilder.BuildWithLength(200);
+            var productInfo = RandomStringBuilder.BuildWithLength(500);
 
             // Act
             var result = testObject.ChangeProductInfo(productInfo, fixture.ChangedBy);


### PR DESCRIPTION
Die maximale Zeichenanzahl für die Beschreibung und Produktinfo eines Gerichtes wurde auf 500 Zeichen erhöht.

Die beinhaltet folgende Änderungen:
* Nutzer kann im Feld Beschreibung und ProductInfo 500 Zeichen eingeben (Textfeld lässt nun auch nicht mehr zu)
* Anzahl der getippten Zeichen werden innerhalb des Feldes angezeigt
* Preis kann nun in ,01 Schritten erhöht werden
* Unit-Test implementiert

![grafik](https://user-images.githubusercontent.com/19330925/116000359-2962b180-a5f0-11eb-91e8-4963cce2217c.png)


Closes #194 