### PR TITLE
Filter disabled categories on the client side

### DIFF
--- a/src/Gastromio.App/ClientApp/src/app/order-ui/components/order-restaurant/order-restaurant.component.html
+++ b/src/Gastromio.App/ClientApp/src/app/order-ui/components/order-restaurant/order-restaurant.component.html
@@ -258,9 +258,9 @@
 									Filter
 								</p>
 								<div class="category-container">
-									<div
-										class="category"
-										*ngFor="let dishCategory of restaurant.dishCategories"
+									<div 
+										 class="category" 
+										 *ngFor="let dishCategory of enabledDishCategories"
 									>
 										<button
 											data-aos="gm-move-down"

--- a/src/Gastromio.App/ClientApp/src/app/order-ui/components/order-restaurant/order-restaurant.component.ts
+++ b/src/Gastromio.App/ClientApp/src/app/order-ui/components/order-restaurant/order-restaurant.component.ts
@@ -53,6 +53,7 @@ export class OrderRestaurantComponent implements OnInit, OnDestroy {
   openingHours: string;
 
   searchPhrase: string;
+  enabledDishCategories: DishCategoryModel[];
   filteredDishCategories: DishCategoryModel[];
 
   allowCart: boolean;
@@ -162,9 +163,10 @@ export class OrderRestaurantComponent implements OnInit, OnDestroy {
                 this.orderFacade.startOrder(orderType, serviceTime);
               }
 
-              this.allowCart = orderType !== OrderType.Reservation;
-
-              this.filterDishCategories();
+          this.allowCart = orderType !== OrderType.Reservation;
+          this.enabledDishCategories = this.restaurant.dishCategories
+            .filter(category => category.enabled);
+          this.filterDishCategories();
 
               this.titleService.setTitle(this.restaurant.name + ' - Gastromio');
 
@@ -264,17 +266,14 @@ export class OrderRestaurantComponent implements OnInit, OnDestroy {
 
   filterDishCategories(): void {
 
-    let enabledDishCategoriesOfRestaurant = this.restaurant.dishCategories
-      .filter(category => category.enabled);
-
     if (!this.searchPhrase) {
-      this.filteredDishCategories = enabledDishCategoriesOfRestaurant
+      this.filteredDishCategories = this.enabledDishCategories;
       return;
     }
 
     this.filteredDishCategories = new Array<DishCategoryModel>();
 
-    for (let dishCategory of enabledDishCategoriesOfRestaurant) {
+    for (let dishCategory of this.enabledDishCategories) {
       let hasMatch = false;
 
       let dishCategoryClone = new DishCategoryModel();

--- a/src/Gastromio.App/ClientApp/src/app/order-ui/components/order-restaurant/order-restaurant.component.ts
+++ b/src/Gastromio.App/ClientApp/src/app/order-ui/components/order-restaurant/order-restaurant.component.ts
@@ -263,14 +263,18 @@ export class OrderRestaurantComponent implements OnInit, OnDestroy {
   }
 
   filterDishCategories(): void {
+
+    let enabledDishCategoriesOfRestaurant = this.restaurant.dishCategories
+      .filter(category => category.enabled);
+
     if (!this.searchPhrase) {
-      this.filteredDishCategories = this.restaurant.dishCategories;
+      this.filteredDishCategories = enabledDishCategoriesOfRestaurant
       return;
     }
 
     this.filteredDishCategories = new Array<DishCategoryModel>();
 
-    for (let dishCategory of this.restaurant.dishCategories) {
+    for (let dishCategory of enabledDishCategoriesOfRestaurant) {
       let hasMatch = false;
 
       let dishCategoryClone = new DishCategoryModel();

--- a/src/Gastromio.Core/Domain/Model/Restaurants/DishCategories.cs
+++ b/src/Gastromio.Core/Domain/Model/Restaurants/DishCategories.cs
@@ -81,7 +81,7 @@ namespace Gastromio.Core.Domain.Model.Restaurants
                 new DishCategoryId(Guid.NewGuid()),
                 name,
                 pos + 1,
-                true,
+                false,
                 new Dishes(Enumerable.Empty<Dish>())
             );
             newDishCategories.Add(dishCategory);


### PR DESCRIPTION
Inactive dish categories was shown when selecting dishes for the order. The category itself and alse the filter tag. Both are now always filterd so that only enabled categories are shown.
Also the default value for dishCategory.Enable was true but on the client it was false. Changed it on the backend so that it is in sync with the client.

Fixes #223 